### PR TITLE
Update ENV variables

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,8 +2,8 @@ require 'yaml'
 
 require File.expand_path('../lib/gitserver', __FILE__)
 
-ENV['OPENSHIFT_INTERNAL_IP'] ||= '127.0.0.1'
-ENV['OPENSHIFT_INTERNAL_PORT'] ||= '8080'
+ENV['OPENSHIFT_DIY_IP'] ||= '127.0.0.1'
+ENV['OPENSHIFT_DIY_PORT'] ||= '8080'
 ENV['OPENSHIFT_DATA_DIR'] ||= './tmp'
 
 server = GitServer.new(YAML.load_file('config.yml'))

--- a/lib/gitserver.rb
+++ b/lib/gitserver.rb
@@ -40,7 +40,7 @@ class GitServer
 
   def start
     GitServer.logger.info('Starting server')
-    @channel = @bootstrap.bind(InetSocketAddress.new(ENV['OPENSHIFT_INTERNAL_IP'], Integer(ENV['OPENSHIFT_INTERNAL_PORT'])))
+    @channel = @bootstrap.bind(InetSocketAddress.new(ENV['OPENSHIFT_DIY_IP'], Integer(ENV['OPENSHIFT_DIY_PORT'])))
   end
 
   def stop


### PR DESCRIPTION
Looks like Openshift has updated its ENV variables which causes this to not work anymore. This replaces the old ENV variables with the new ones :)